### PR TITLE
Remove eclipse folder from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Eclipse files
+eclipse


### PR DESCRIPTION
When using Gradle there is no reason to keep the "eclipse" folder in the repository as you can simply run "gradlew eclipse" to generate the necessary files.